### PR TITLE
New version 1.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,17 +3,21 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.hpn789.plextozidoo"
         minSdkVersion 28
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
-        versionName "1.0"
+        versionName "1.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    applicationVariants.all { variant ->
+        variant.resValue "string", "versionName", variant.versionName
     }
 
     buildTypes {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,8 +14,12 @@
         android:theme="@style/Theme.PlexToZidoo">
         <activity
             android:name=".SettingsActivity"
-            android:label="@string/title_activity_settings" />
-        <activity android:name=".Play">
+            android:label="@string/title_activity_settings"
+            android:theme="@style/Theme.PlexToZidoo.Settings"/>
+        <activity
+            android:name=".Play"
+            android:theme="@style/Theme.PlexToZidoo.Play"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -52,7 +56,7 @@
         </activity>
         <activity
             android:name=".TestActivity"
-            android:label="@string/app_name">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/hpn789/plextozidoo/Play.java
+++ b/app/src/main/java/com/hpn789/plextozidoo/Play.java
@@ -3,17 +3,17 @@ package com.hpn789.plextozidoo;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.PreferenceManager;
 
-import android.content.Context;
+import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
+import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
-import com.android.volley.Response;
-import com.android.volley.VolleyError;
 import com.android.volley.toolbox.StringRequest;
 import com.android.volley.toolbox.Volley;
 
@@ -22,19 +22,24 @@ import org.xmlpull.v1.XmlPullParserException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 public class Play extends AppCompatActivity {
 
-    static final String library = "/library/";
     static final String tokenParameter = "X-Plex-Token=";
+    private Intent intent;
     private String address = "";
-    private String key = "";
+    private String videoKey = "";
+    private String libraryKey = "";
     private String token = "";
+    private int duration = 0;
+    private int viewOffset = 0;
+    private String directPath = "";
 
     private TextView textView;
+    private Button playButton;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -52,51 +57,51 @@ public class Play extends AppCompatActivity {
     {
         PlexLibraryInfo info = infos.get(index);
         RequestQueue queue = Volley.newRequestQueue(this);
-        String url =address+"/library/sections/"+info.getKey()+"/search?type="+info.getType().searchId+"&"+tokenParameter+token;
+        String url = address + "/library/sections/" + info.getKey() + "/search?type=" + info.getType().searchId + "&" + tokenParameter + token;
         // Request a string response from the provided URL.
         StringRequest stringRequest = new StringRequest(Request.Method.GET, url,
-                new Response.Listener<String>() {
-                    @Override
-                    public void onResponse(String response) {
-                        // Display the first 500 characters of the response string.
-                        PlexLibraryXmlParser parser = new PlexLibraryXmlParser(key);
-                        InputStream targetStream = new ByteArrayInputStream(response.getBytes());
-                        try {
-                            String path = parser.parse(targetStream);
-                            if(!path.isEmpty())
+                response -> {
+                    // Display the first 500 characters of the response string.
+                    PlexLibraryXmlParser parser = new PlexLibraryXmlParser(libraryKey);
+                    InputStream targetStream = new ByteArrayInputStream(response.getBytes());
+                    try {
+                        String path = parser.parse(targetStream);
+                        if(!path.isEmpty())
+                        {
+                            directPath = plexPathToLocalPath(path);
+                            videoKey = parser.getVideoKey();
+                            duration = parser.getDuration();
+
+                            // If the debug flag is on then update the text field
+                            if(PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getBoolean("debug", false))
                             {
-                                path=plexPathToLocalPath(path);
-                                if(PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getBoolean("useZidooPlayer", true))
-                                {
-                                    startZidooPlayer(path, info.getViewOffset());
-                                }
-                                else
-                                {
-                                    startPlayer(path);
-                                }
+                                // If the path has a password in it then hide it from the debug output
+                                String password = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("smbPassword", "");
+                                String pathToPrint = directPath.replaceAll(":" + password + "@", ":********@");
+                                textView.setText(String.format(Locale.ENGLISH, "Intent: %s\n\nPath Substitution: %s\n\nView Offset: %d\n\nDuration: %d\n\nAddress: %s\n\nVideo Key: %s\n\nToken: %s\n\nLibrary Key: %s\n\nMedia Type: %s", intentToString(intent), pathToPrint, viewOffset, duration, address, videoKey, token, info.getKey(), info.getType().name));
+                                playButton.setEnabled(true);
                             }
-                            else if(index+1<infos.size())
-                            {
-                                searchPath(infos, index+1);
-                            }
+                            // Else just play the movie
                             else
                             {
-                                textView.setText("Not found");
+                                playButton.callOnClick();
                             }
-
-                        } catch (XmlPullParserException e) {
-                            e.printStackTrace();
-                        } catch (IOException e) {
-                            e.printStackTrace();
+                        }
+                        else if(index + 1 < infos.size())
+                        {
+                            searchPath(infos, index + 1);
+                        }
+                        else
+                        {
+                            textView.setText(String.format(Locale.ENGLISH, "Not found\n\nIntent: %s", intentToString(intent)));
                         }
 
+                    } catch (Exception e) {
+                        e.printStackTrace();
                     }
-                }, new Response.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError error) {
-                textView.setText("That didn't work!");
-            }
-        });
+
+                },
+                error -> textView.setText("That didn't work"));
 
 // Add the request to the RequestQueue.
         queue.add(stringRequest);
@@ -105,33 +110,24 @@ public class Play extends AppCompatActivity {
     private void searchLibrary()
     {
         RequestQueue queue = Volley.newRequestQueue(this);
-        String url =address+"/library/sections/?"+tokenParameter+token;
+        String url = address + "/library/sections/?" + tokenParameter + token;
         // Request a string response from the provided URL.
         StringRequest stringRequest = new StringRequest(Request.Method.GET, url,
-                new Response.Listener<String>() {
-                    @Override
-                    public void onResponse(String response) {
-                        // Display the first 500 characters of the response string.
-                        String[] names = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("libraries", "").split(",");
-                        PlexXmlParser parser = new PlexXmlParser(Arrays.asList(names));
-                        InputStream targetStream = new ByteArrayInputStream(response.getBytes());
-                        try {
-                            List<PlexLibraryInfo> libraries = parser.parse(targetStream);
-                            searchPath(libraries, 0);
+                response -> {
+                    // Display the first 500 characters of the response string.
+                    String[] names = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("libraries", "").split(",");
+                    PlexXmlParser parser = new PlexXmlParser(Arrays.asList(names));
+                    InputStream targetStream = new ByteArrayInputStream(response.getBytes());
+                    try {
+                        List<PlexLibraryInfo> libraries = parser.parse(targetStream);
+                        searchPath(libraries, 0);
 
-                        } catch (XmlPullParserException e) {
-                            e.printStackTrace();
-                        } catch (IOException e) {
-                            e.printStackTrace();
-                        }
-
+                    } catch (XmlPullParserException | IOException e) {
+                        e.printStackTrace();
                     }
-                }, new Response.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError error) {
-                textView.setText("That didn't work!");
-            }
-        });
+
+                },
+                error -> textView.setText("That didn't work!"));
 
 // Add the request to the RequestQueue.
         queue.add(stringRequest);
@@ -141,17 +137,30 @@ public class Play extends AppCompatActivity {
     protected void onStart() {
         super.onStart();
 
-        Intent intent = getIntent();
+        intent = getIntent();
 
-        String dataString = intent.getDataString();
-        Log.d("plex", ""+dataString);
-        int indexOfLibrary = dataString.indexOf("/library/");
-        address = dataString.substring(0, indexOfLibrary);
-        key = dataString.substring(indexOfLibrary, dataString.indexOf("?"));
-        String tmp = dataString.substring(dataString.indexOf(tokenParameter)+tokenParameter.length());
+        String inputString = intent.getDataString();
+        Log.d("plex", "" + inputString);
+        int indexOfLibrary = inputString.indexOf("/library/");
+        address = inputString.substring(0, indexOfLibrary);
+        libraryKey = inputString.substring(indexOfLibrary, inputString.indexOf("?"));
+        String tmp = inputString.substring(inputString.indexOf(tokenParameter) + tokenParameter.length());
         token = tmp.contains("&") ? tmp.substring(0, tmp.indexOf("&")) : tmp;
 
-        textView = (TextView) findViewById(R.id.textView2);
+        viewOffset = intent.getIntExtra("viewOffset", 0);
+
+        textView = findViewById(R.id.textView2);
+        playButton = findViewById(R.id.play_button);
+        playButton.setOnClickListener(v -> {
+            if (PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getBoolean("useZidooPlayer", true))
+            {
+                startZidooPlayer(directPath, viewOffset);
+            }
+            else
+            {
+                startPlayer(directPath);
+            }
+        });
 
         searchLibrary();
 
@@ -166,52 +175,106 @@ public class Play extends AppCompatActivity {
 
     protected String plexPathToLocalPath(String path)
     {
-        String replaced = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("path_to_replace", "");
-        if(!replaced.equals(""))
+        String path_to_replace = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("path_to_replace", "");
+        if(!path_to_replace.equals(""))
         {
-            return path.replace(replaced,PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("replaced_with", ""));
+            String replace_with = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("replaced_with", "");
+            path = path.replace(path_to_replace, replace_with).replace("\\", "/");
+
+            String username = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("smbUsername", "");
+            if(!username.equals(""))
+            {
+                String password = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("smbPassword", "");
+                path = path.replace("smb://", "smb://" + username + ":" + password + "@");
+            }
         }
         return path;
     }
 
     protected void startZidooPlayer(String path, int viewOffset)
     {
+        // see https://github.com/Andy2244/jellyfin-androidtv-zidoo/blob/Zidoo-Edition/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
+        // NOTE: This code requires the new ZIDOO API to work. 6.4.42+
+        Intent newIntent = new Intent(Intent.ACTION_VIEW);
 
-        //see https://github.com/Andy2244/jellyfin-androidtv-zidoo/blob/Zidoo-Edition/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
-        Intent newIntent = new Intent();
-
-        String from = "Local";
-        newIntent.putExtra("SourceFrom", from);
         newIntent.setDataAndType(Uri.parse(path), "video/mkv");
-
-
-        newIntent.putExtra("MEDIA_BROWSER_USE_RT_MEDIA_PLAYER", true);
-        newIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
-        newIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        newIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        newIntent.addFlags(Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
         newIntent.setPackage("com.android.gallery3d");
-        newIntent.setClassName("com.android.gallery3d", "com.android.gallery3d.app.ZDMCActivity");
+        newIntent.setClassName("com.android.gallery3d", "com.android.gallery3d.app.MovieActivity");
 
-        String mode = "zdmc";
-        newIntent.putExtra("play_mode", mode);
-        String net_work = "local";
-        net_work = "smb";
-        newIntent.putExtra("net_mode", net_work);
-
-        String username = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("smbUsername", "");
-        if(!username.equals(""))
+        if(viewOffset > 0)
         {
-            newIntent.putExtra("smb_username",username);
-            newIntent.putExtra("smb_password", PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("smbPassword", ""));
+            newIntent.putExtra("from_start", false);
+            newIntent.putExtra("position", viewOffset);
+        }
+        else
+        {
+            newIntent.putExtra("from_start", true);
         }
 
-        startActivity(newIntent);
+        newIntent.putExtra("return_result", true);
 
+        startActivityForResult(newIntent, 98);
     }
 
 
     @Override
     protected void onStop() {
         super.onStop();
+
+    }
+
+    protected void onActivityResult(int requestCode, int resultCode, Intent data)
+    {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if(resultCode == Activity.RESULT_OK && requestCode == 98)
+        {
+            int position = data.getIntExtra("position", 0);
+            if(position > 0)
+            {
+                RequestQueue queue = Volley.newRequestQueue(this);
+                String url;
+                if(duration > 0 && position > (duration * .9))
+                {
+                    // Mark it as watched
+                    url = address + "/:/scrobble?key=" + videoKey + "&identifier=com.plexapp.plugins.library&" + tokenParameter + token;
+                }
+                else
+                {
+                    // Update progress
+                    url = address + "/:/progress?key=" + videoKey + "&identifier=com.plexapp.plugins.library&time=" + position + "&state=stopped&" + tokenParameter + token;
+                }
+
+                StringRequest stringRequest = new StringRequest(Request.Method.GET, url,
+                        response -> {
+                            // Nothing to do
+                        },
+                        error -> Toast.makeText(getApplicationContext(), "That didn't work!", Toast.LENGTH_LONG).show()
+                );
+
+                // Add the request to the RequestQueue.
+                queue.add(stringRequest);
+            }
+        }
+    }
+
+    public static String intentToString(Intent intent)
+    {
+        if (intent == null)
+            return "";
+
+        StringBuilder stringBuilder = new StringBuilder("action: ")
+                .append(intent.getAction())
+                .append(" data: ")
+                .append(intent.getDataString())
+                .append(" extras: ")
+                ;
+        for (String key : intent.getExtras().keySet())
+            stringBuilder.append(key).append("=").append(intent.getExtras().get(key)).append(" ");
+
+        return stringBuilder.toString();
 
     }
 }

--- a/app/src/main/java/com/hpn789/plextozidoo/Play.java
+++ b/app/src/main/java/com/hpn789/plextozidoo/Play.java
@@ -3,17 +3,17 @@ package com.hpn789.plextozidoo;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.PreferenceManager;
 
-import android.content.Context;
+import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
+import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
-import com.android.volley.Response;
-import com.android.volley.VolleyError;
 import com.android.volley.toolbox.StringRequest;
 import com.android.volley.toolbox.Volley;
 
@@ -22,19 +22,24 @@ import org.xmlpull.v1.XmlPullParserException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 public class Play extends AppCompatActivity {
 
-    static final String library = "/library/";
     static final String tokenParameter = "X-Plex-Token=";
+    private Intent intent;
     private String address = "";
-    private String key = "";
+    private String videoKey = "";
+    private String libraryKey = "";
     private String token = "";
+    private int duration = 0;
+    private int viewOffset = 0;
+    private String directPath = "";
 
     private TextView textView;
+    private Button playButton;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -52,51 +57,48 @@ public class Play extends AppCompatActivity {
     {
         PlexLibraryInfo info = infos.get(index);
         RequestQueue queue = Volley.newRequestQueue(this);
-        String url =address+"/library/sections/"+info.getKey()+"/search?type="+info.getType().searchId+"&"+tokenParameter+token;
+        String url = address + "/library/sections/" + info.getKey() + "/search?type=" + info.getType().searchId + "&" + tokenParameter + token;
         // Request a string response from the provided URL.
         StringRequest stringRequest = new StringRequest(Request.Method.GET, url,
-                new Response.Listener<String>() {
-                    @Override
-                    public void onResponse(String response) {
-                        // Display the first 500 characters of the response string.
-                        PlexLibraryXmlParser parser = new PlexLibraryXmlParser(key);
-                        InputStream targetStream = new ByteArrayInputStream(response.getBytes());
-                        try {
-                            String path = parser.parse(targetStream);
-                            if(!path.isEmpty())
+                response -> {
+                    // Display the first 500 characters of the response string.
+                    PlexLibraryXmlParser parser = new PlexLibraryXmlParser(libraryKey);
+                    InputStream targetStream = new ByteArrayInputStream(response.getBytes());
+                    try {
+                        String path = parser.parse(targetStream);
+                        if(!path.isEmpty())
+                        {
+                            directPath = plexPathToLocalPath(path);
+                            videoKey = parser.getVideoKey();
+                            duration = parser.getDuration();
+
+                            // If the debug flag is on then update the text field
+                            if(PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getBoolean("debug", false))
                             {
-                                path=plexPathToLocalPath(path);
-                                if(PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getBoolean("useZidooPlayer", true))
-                                {
-                                    startZidooPlayer(path, info.getViewOffset());
-                                }
-                                else
-                                {
-                                    startPlayer(path);
-                                }
+                                textView.setText(String.format(Locale.ENGLISH, "Intent: %s\n\nPath Substitution: %s\n\nView Offset: %d\n\nDuration: %d\n\nAddress: %s\n\nVideo Key: %s\n\nToken: %s\n\nLibrary Key: %s\n\nMedia Type: %s", intentToString(intent), directPath, viewOffset, duration, address, videoKey, token, info.getKey(), info.getType().name));
+                                playButton.setEnabled(true);
                             }
-                            else if(index+1<infos.size())
-                            {
-                                searchPath(infos, index+1);
-                            }
+                            // Else just play the movie
                             else
                             {
-                                textView.setText("Not found");
+                                playButton.callOnClick();
                             }
-
-                        } catch (XmlPullParserException e) {
-                            e.printStackTrace();
-                        } catch (IOException e) {
-                            e.printStackTrace();
+                        }
+                        else if(index + 1 < infos.size())
+                        {
+                            searchPath(infos, index + 1);
+                        }
+                        else
+                        {
+                            textView.setText(String.format(Locale.ENGLISH, "Not found\n\nIntent: %s", intentToString(intent)));
                         }
 
+                    } catch (Exception e) {
+                        e.printStackTrace();
                     }
-                }, new Response.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError error) {
-                textView.setText("That didn't work!");
-            }
-        });
+
+                },
+                error -> textView.setText("That didn't work"));
 
 // Add the request to the RequestQueue.
         queue.add(stringRequest);
@@ -105,33 +107,24 @@ public class Play extends AppCompatActivity {
     private void searchLibrary()
     {
         RequestQueue queue = Volley.newRequestQueue(this);
-        String url =address+"/library/sections/?"+tokenParameter+token;
+        String url = address + "/library/sections/?" + tokenParameter + token;
         // Request a string response from the provided URL.
         StringRequest stringRequest = new StringRequest(Request.Method.GET, url,
-                new Response.Listener<String>() {
-                    @Override
-                    public void onResponse(String response) {
-                        // Display the first 500 characters of the response string.
-                        String[] names = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("libraries", "").split(",");
-                        PlexXmlParser parser = new PlexXmlParser(Arrays.asList(names));
-                        InputStream targetStream = new ByteArrayInputStream(response.getBytes());
-                        try {
-                            List<PlexLibraryInfo> libraries = parser.parse(targetStream);
-                            searchPath(libraries, 0);
+                response -> {
+                    // Display the first 500 characters of the response string.
+                    String[] names = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("libraries", "").split(",");
+                    PlexXmlParser parser = new PlexXmlParser(Arrays.asList(names));
+                    InputStream targetStream = new ByteArrayInputStream(response.getBytes());
+                    try {
+                        List<PlexLibraryInfo> libraries = parser.parse(targetStream);
+                        searchPath(libraries, 0);
 
-                        } catch (XmlPullParserException e) {
-                            e.printStackTrace();
-                        } catch (IOException e) {
-                            e.printStackTrace();
-                        }
-
+                    } catch (XmlPullParserException | IOException e) {
+                        e.printStackTrace();
                     }
-                }, new Response.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError error) {
-                textView.setText("That didn't work!");
-            }
-        });
+
+                },
+                error -> textView.setText("That didn't work!"));
 
 // Add the request to the RequestQueue.
         queue.add(stringRequest);
@@ -141,17 +134,30 @@ public class Play extends AppCompatActivity {
     protected void onStart() {
         super.onStart();
 
-        Intent intent = getIntent();
+        intent = getIntent();
 
-        String dataString = intent.getDataString();
-        Log.d("plex", ""+dataString);
-        int indexOfLibrary = dataString.indexOf("/library/");
-        address = dataString.substring(0, indexOfLibrary);
-        key = dataString.substring(indexOfLibrary, dataString.indexOf("?"));
-        String tmp = dataString.substring(dataString.indexOf(tokenParameter)+tokenParameter.length());
+        String inputString = intent.getDataString();
+        Log.d("plex", "" + inputString);
+        int indexOfLibrary = inputString.indexOf("/library/");
+        address = inputString.substring(0, indexOfLibrary);
+        libraryKey = inputString.substring(indexOfLibrary, inputString.indexOf("?"));
+        String tmp = inputString.substring(inputString.indexOf(tokenParameter) + tokenParameter.length());
         token = tmp.contains("&") ? tmp.substring(0, tmp.indexOf("&")) : tmp;
 
-        textView = (TextView) findViewById(R.id.textView2);
+        viewOffset = intent.getIntExtra("viewOffset", 0);
+
+        textView = findViewById(R.id.textView2);
+        playButton = findViewById(R.id.play_button);
+        playButton.setOnClickListener(v -> {
+            if (PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getBoolean("useZidooPlayer", true))
+            {
+                startZidooPlayer(directPath, viewOffset);
+            }
+            else
+            {
+                startPlayer(directPath);
+            }
+        });
 
         searchLibrary();
 
@@ -169,49 +175,104 @@ public class Play extends AppCompatActivity {
         String replaced = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("path_to_replace", "");
         if(!replaced.equals(""))
         {
-            return path.replace(replaced,PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("replaced_with", ""));
+            return path.replace(replaced, PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("replaced_with", "")).replace("\\", "/");
         }
         return path;
     }
 
     protected void startZidooPlayer(String path, int viewOffset)
     {
-
-        //see https://github.com/Andy2244/jellyfin-androidtv-zidoo/blob/Zidoo-Edition/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
-        Intent newIntent = new Intent();
+        // see https://github.com/Andy2244/jellyfin-androidtv-zidoo/blob/Zidoo-Edition/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
+        // NOTE: This code requires the new ZIDOO API to work. 6.4.42+
+        Intent newIntent = new Intent(Intent.ACTION_VIEW);
 
         String from = "Local";
         newIntent.putExtra("SourceFrom", from);
         newIntent.setDataAndType(Uri.parse(path), "video/mkv");
-
-
-        newIntent.putExtra("MEDIA_BROWSER_USE_RT_MEDIA_PLAYER", true);
-        newIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
-        newIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        newIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        newIntent.addFlags(Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
         newIntent.setPackage("com.android.gallery3d");
-        newIntent.setClassName("com.android.gallery3d", "com.android.gallery3d.app.ZDMCActivity");
+        newIntent.setClassName("com.android.gallery3d", "com.android.gallery3d.app.MovieActivity");
 
-        String mode = "zdmc";
-        newIntent.putExtra("play_mode", mode);
-        String net_work = "local";
-        net_work = "smb";
-        newIntent.putExtra("net_mode", net_work);
+        if(viewOffset > 0)
+        {
+            newIntent.putExtra("from_start", false);
+            newIntent.putExtra("position", viewOffset);
+        }
+        else
+        {
+            newIntent.putExtra("from_start", true);
+        }
+
+        newIntent.putExtra("return_result", true);
 
         String username = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("smbUsername", "");
         if(!username.equals(""))
         {
-            newIntent.putExtra("smb_username",username);
+            newIntent.putExtra("smb_username", username);
             newIntent.putExtra("smb_password", PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("smbPassword", ""));
         }
 
-        startActivity(newIntent);
-
+        startActivityForResult(newIntent, 98);
     }
 
 
     @Override
     protected void onStop() {
         super.onStop();
+
+    }
+
+    protected void onActivityResult(int requestCode, int resultCode, Intent data)
+    {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if(resultCode == Activity.RESULT_OK && requestCode == 98)
+        {
+            int position = data.getIntExtra("position", 0);
+            if(position > 0)
+            {
+                RequestQueue queue = Volley.newRequestQueue(this);
+                String url;
+                if(duration > 0 && position > (duration * .9))
+                {
+                    // Mark it as watched
+                    url = address + "/:/scrobble?key=" + videoKey + "&identifier=com.plexapp.plugins.library&" + tokenParameter + token;
+                }
+                else
+                {
+                    // Update progress
+                    url = address + "/:/progress?key=" + videoKey + "&identifier=com.plexapp.plugins.library&time=" + position + "&state=stopped&" + tokenParameter + token;
+                }
+
+                StringRequest stringRequest = new StringRequest(Request.Method.GET, url,
+                        response -> {
+                            // Nothing to do
+                        },
+                        error -> Toast.makeText(getApplicationContext(), "That didn't work!", Toast.LENGTH_LONG).show()
+                );
+
+                // Add the request to the RequestQueue.
+                queue.add(stringRequest);
+            }
+        }
+    }
+
+    public static String intentToString(Intent intent)
+    {
+        if (intent == null)
+            return "";
+
+        StringBuilder stringBuilder = new StringBuilder("action: ")
+                .append(intent.getAction())
+                .append(" data: ")
+                .append(intent.getDataString())
+                .append(" extras: ")
+                ;
+        for (String key : intent.getExtras().keySet())
+            stringBuilder.append(key).append("=").append(intent.getExtras().get(key)).append(" ");
+
+        return stringBuilder.toString();
 
     }
 }

--- a/app/src/main/java/com/hpn789/plextozidoo/PlexLibraryInfo.java
+++ b/app/src/main/java/com/hpn789/plextozidoo/PlexLibraryInfo.java
@@ -1,15 +1,13 @@
 package com.hpn789.plextozidoo;
 
 public class PlexLibraryInfo {
-    private String key;
-    private PlexMediaType type;
-    private int viewOffset;
+    private final String key;
+    private final PlexMediaType type;
 
-    public PlexLibraryInfo(String aKey, PlexMediaType aType, int aViewOffset)
+    public PlexLibraryInfo(String aKey, PlexMediaType aType)
     {
-        key=aKey;
-        type=aType;
-        viewOffset=aViewOffset;
+        key = aKey;
+        type = aType;
     }
 
     public PlexMediaType getType() {
@@ -20,7 +18,4 @@ public class PlexLibraryInfo {
         return key;
     }
 
-    public int getViewOffset() {
-        return viewOffset;
-    }
 }

--- a/app/src/main/java/com/hpn789/plextozidoo/PlexLibraryXmlParser.java
+++ b/app/src/main/java/com/hpn789/plextozidoo/PlexLibraryXmlParser.java
@@ -7,22 +7,22 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
 
 public class PlexLibraryXmlParser {
 
     // We don't use namespaces
     private static final String ns = null;
     private String path = "";
+    private String videoKey = "";
+    private int duration = 0;
 
-    private String key;
+    private final String libraryKey;
 
     //public List<String> entries = new ArrayList<String>();
 
     public PlexLibraryXmlParser(String aKey)
     {
-        key=aKey;
+        libraryKey = aKey;
     }
 
     public String parse(InputStream in) throws XmlPullParserException, IOException {
@@ -38,6 +38,16 @@ public class PlexLibraryXmlParser {
         }
     }
 
+    public String getVideoKey()
+    {
+        return videoKey;
+    }
+
+    public int getDuration()
+    {
+        return duration;
+    }
+
     private void readXML(XmlPullParser parser) throws XmlPullParserException, IOException {
 
         parser.require(XmlPullParser.START_TAG, ns, "MediaContainer");
@@ -47,9 +57,24 @@ public class PlexLibraryXmlParser {
             }
             String name = parser.getName();
             // Starts by looking for the entry tag
-            if (name.equals("Video")) {
+            if(name.equals("Video"))
+            {
+                videoKey = parser.getAttributeValue(null, "ratingKey");
+
+                String durationText = parser.getAttributeValue(null, "duration");
+                try
+                {
+                    duration = Integer.parseInt(durationText);
+                }
+                catch(NumberFormatException e)
+                {
+                    duration = 0;
+                }
+
                 readVideo(parser);
-            } else {
+            }
+            else
+            {
                 skip(parser);
             }
         }
@@ -88,7 +113,7 @@ public class PlexLibraryXmlParser {
     // Processes link tags in the feed.
     private void readPart(XmlPullParser parser) throws IOException, XmlPullParserException {
         String keyAttribute = parser.getAttributeValue(null, "key");
-        if(keyAttribute.equals(key))
+        if(keyAttribute.equals(libraryKey))
         {
             path = parser.getAttributeValue(null, "file");
         }

--- a/app/src/main/java/com/hpn789/plextozidoo/PlexXmlParser.java
+++ b/app/src/main/java/com/hpn789/plextozidoo/PlexXmlParser.java
@@ -14,15 +14,15 @@ public class PlexXmlParser {
 
     // We don't use namespaces
     private static final String ns = null;
-    private List<PlexLibraryInfo> infos = new ArrayList<>();
+    private final List<PlexLibraryInfo> infos = new ArrayList<>();
 
-    private List<String> titles;
+    private final List<String> titles;
 
     //public List<String> entries = new ArrayList<String>();
 
     public PlexXmlParser(List<String> aTitles)
     {
-        titles=aTitles;
+        titles = aTitles;
     }
 
     public List<PlexLibraryInfo> parse(InputStream in) throws XmlPullParserException, IOException {
@@ -56,28 +56,19 @@ public class PlexXmlParser {
         }
     }
 
-    private void readDirectory(XmlPullParser parser) throws XmlPullParserException, IOException {
+    private void readDirectory(XmlPullParser parser) {
 
         String titleValue = parser.getAttributeValue(null, "title");
         if(titles.contains(titleValue))
         {
             String key = parser.getAttributeValue(null, "key");
             String type = parser.getAttributeValue(null, "type");
-            String viewOffsetText = parser.getAttributeValue(null, "viewOffset");
-            int viewOffset;
-            try
-            {
-                viewOffset = Integer.parseInt(viewOffsetText);
-            }
-            catch(NumberFormatException e)
-            {
-                viewOffset=0;
-            }
+
             for(PlexMediaType mt : PlexMediaType.values())
             {
                 if(mt.name.equals(type))
                 {
-                    infos.add(new PlexLibraryInfo(key, mt, viewOffset));
+                    infos.add(new PlexLibraryInfo(key, mt));
                 }
             }
         }

--- a/app/src/main/java/com/hpn789/plextozidoo/SettingsActivity.java
+++ b/app/src/main/java/com/hpn789/plextozidoo/SettingsActivity.java
@@ -1,9 +1,13 @@
 package com.hpn789.plextozidoo;
 
 import android.os.Bundle;
+import android.text.InputType;
+import android.widget.EditText;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.preference.EditTextPreference;
 import androidx.preference.PreferenceFragmentCompat;
 
 public class SettingsActivity extends AppCompatActivity {
@@ -28,6 +32,12 @@ public class SettingsActivity extends AppCompatActivity {
         @Override
         public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
             setPreferencesFromResource(R.xml.root_preferences, rootKey);
+
+            EditTextPreference preference = findPreference("smbPassword");
+            if (preference!= null) {
+                preference.setOnBindEditTextListener(
+                        editText -> editText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD));
+            }
         }
     }
 }

--- a/app/src/main/java/com/hpn789/plextozidoo/TestActivity.java
+++ b/app/src/main/java/com/hpn789/plextozidoo/TestActivity.java
@@ -2,21 +2,11 @@ package com.hpn789.plextozidoo;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.StrictMode;
 import android.util.Log;
 import android.widget.Button;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.PreferenceFragmentCompat;
-
-import java.io.BufferedInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-
-import javax.net.ssl.HttpsURLConnection;
 
 public class TestActivity extends AppCompatActivity {
 
@@ -28,10 +18,8 @@ public class TestActivity extends AppCompatActivity {
 
         setContentView(R.layout.test_activity);
 
-        Button settingsButton = (Button) findViewById(R.id.settings_button);
-        settingsButton.setOnClickListener(v->{
-            startActivity(new Intent(this, SettingsActivity.class));
-        });
+        Button settingsButton = findViewById(R.id.settings_button);
+        settingsButton.setOnClickListener(v-> startActivity(new Intent(this, SettingsActivity.class)));
     }
 
 

--- a/app/src/main/res/layout/activity_play.xml
+++ b/app/src/main/res/layout/activity_play.xml
@@ -4,18 +4,26 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#000000"
     tools:context=".Play">
 
     <TextView
         android:id="@+id/textView2"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="Searching on plex"
         android:textColor="#FFFFFF"
-        android:textSize="18sp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginLeft="16dp"
+        android:layout_marginRight="16dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/play_button"
+        android:enabled="false"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/play_button_title"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_play.xml
+++ b/app/src/main/res/layout/activity_play.xml
@@ -4,18 +4,24 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#000000"
     tools:context=".Play">
 
     <TextView
         android:id="@+id/textView2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Searching on plex"
         android:textColor="#FFFFFF"
-        android:textSize="18sp"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/play_button"
+        android:enabled="false"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/play_button_title"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/settings_activity.xml
+++ b/app/src/main/res/layout/settings_activity.xml
@@ -7,10 +7,4 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-    <FrameLayout
-        android:id="@+id/settings"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-
-
 </LinearLayout>

--- a/app/src/main/res/layout/test_activity.xml
+++ b/app/src/main/res/layout/test_activity.xml
@@ -1,6 +1,4 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -18,6 +16,7 @@
             android:text="@string/settings_button_title" />
 
         <Button
+            android:clickable="false"
             android:id="@+id/clearCache_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,12 +11,15 @@
 
 
     <!-- Preference Titles -->
+    <string name="version_settings">Version</string>
+    <string name="general_settings">General</string>
     <string name="player_settings">Player</string>
     <string name="plex_settings">Plex</string>
     <string name="smb_settings">Smb</string>
 
     <!-- Player Preferences -->
     <string name="useZidooPlayer_title">Use zidoo native player</string>
+    <string name="debug_title">Debug data</string>
     <!-- Plex Preferences -->
     <string name="libraries_title">Plex libraries name to search-in (separated by ",")</string>
     <string name="path_to_replace">Part of the path to replace</string>
@@ -25,5 +28,8 @@
     <!-- Smb Preferences -->
     <string name="smbUsername_title">Smb username (if needed)</string>
     <string name="smbPassword_title">Smb password (if needed)</string>
+
+    <!-- Play activity -->
+    <string name="play_button_title">Play</string>
 
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,4 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
     <!-- Base application theme. -->
     <style name="Theme.PlexToZidoo" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Primary brand color. -->
@@ -10,7 +10,35 @@
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor" >?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
+        <item name="android:windowBackground">@android:color/black</item>
+    </style>
+    <style name="Theme.PlexToZidoo.Settings" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <!-- Primary brand color. -->
+        <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorOnPrimary">@color/white</item>
+        <!-- Secondary brand color. -->
+        <item name="colorSecondary">@color/teal_200</item>
+        <item name="colorSecondaryVariant">@color/teal_700</item>
+        <item name="colorOnSecondary">@color/black</item>
+        <!-- Status bar color. -->
+        <item name="android:statusBarColor" >?attr/colorPrimaryVariant</item>
+        <!-- Customize your theme here. -->
+    </style>
+    <style name="Theme.PlexToZidoo.Play" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <!-- Primary brand color. -->
+        <item name="colorPrimary">@android:color/black</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorOnPrimary">@color/white</item>
+        <!-- Secondary brand color. -->
+        <item name="colorSecondary">@color/teal_200</item>
+        <item name="colorSecondaryVariant">@color/teal_700</item>
+        <item name="colorOnSecondary">@color/black</item>
+        <!-- Status bar color. -->
+        <item name="android:statusBarColor" >@android:color/black</item>
+        <!-- Customize your theme here. -->
+        <item name="android:windowBackground">@android:color/black</item>
     </style>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -1,11 +1,29 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <Preference
+        android:key="version"
+        android:selectable="false"
+        android:persistent="false"
+        android:title="@string/version_settings"
+        android:summary="@string/versionName"/>
+
+    <PreferenceCategory app:title="@string/general_settings">
+
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="debug"
+            android:title="@string/debug_title" />
+
+    </PreferenceCategory>
+
     <PreferenceCategory app:title="@string/player_settings">
+
         <SwitchPreference
             android:defaultValue="true"
             android:key="useZidooPlayer"
             android:title="@string/useZidooPlayer_title" />
+
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/plex_settings">
@@ -41,17 +59,17 @@
     <PreferenceCategory app:title="@string/smb_settings">
 
         <EditTextPreference
-            app:defaultValue="none"
+            app:defaultValue=""
             app:key="smbUsername"
             app:title="@string/smbUsername_title"
             app:useSimpleSummaryProvider="true" />
 
         <EditTextPreference
-            app:defaultValue="none"
+            app:defaultValue=""
             app:key="smbPassword"
             app:title="@string/smbPassword_title"
             android:inputType="textPassword"
-            app:useSimpleSummaryProvider="true" />
+            app:useSimpleSummaryProvider="false" />
 
     </PreferenceCategory>
 

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -1,11 +1,29 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <Preference
+        android:key="version"
+        android:selectable="false"
+        android:persistent="false"
+        android:title="@string/version_settings"
+        android:summary="@string/versionName"/>
+
+    <PreferenceCategory app:title="@string/general_settings">
+
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="debug"
+            android:title="@string/debug_title" />
+
+    </PreferenceCategory>
+
     <PreferenceCategory app:title="@string/player_settings">
+
         <SwitchPreference
             android:defaultValue="true"
             android:key="useZidooPlayer"
             android:title="@string/useZidooPlayer_title" />
+
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/plex_settings">


### PR DESCRIPTION
- Convert backslash's to forward slash's for windows SMB support
- Fully support resume status on PLEX
  - Start from a resume point
  - Update resume point after playback
  - Uses new ZIDOO API available in version 6.4.42+
- Add debug info to help users figure out substitution issues
  - Can be turned off with new debug setting
- Make play intent screen black so it's less intrusive
- Make "Clear Cache" button un-clickable until support is added